### PR TITLE
0.8.3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-0.8.1-blue.svg)](https://pypi.org/project/mayatk/)
+[![Version](https://img.shields.io/badge/Version-0.8.3-blue.svg)](https://pypi.org/project/mayatk/)
 [![CoreUtils Tests](https://img.shields.io/badge/CoreUtils-Passing-brightgreen.svg)](../test/core_utils_test.py#CoreUtilsTest)
 [![ProjUtils Tests](https://img.shields.io/badge/ProjUtils-Passing-brightgreen.svg)](../test/proj_utils_test.py#ProjUtilsTest)
 [![XformUtils Tests](https://img.shields.io/badge/XformUtils-Passing-brightgreen.svg)](../test/xform_utils_test.py#XformUtilsTest)

--- a/mayatk/__init__.py
+++ b/mayatk/__init__.py
@@ -6,7 +6,7 @@ import pkgutil
 
 
 __package__ = "mayatk"
-__version__ = "0.8.1"
+__version__ = "0.8.3"
 
 """Dynamic Attribute Resolver for Module-based Packages
 

--- a/mayatk/edit_utils/duplicate_linear.py
+++ b/mayatk/edit_utils/duplicate_linear.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 try:
     import pymel.core as pm
+    import maya.api.OpenMaya as om
 except ImportError as error:
     print(__file__, error)
 import pythontk as ptk
@@ -28,22 +29,17 @@ class DuplicateLinear:
         originals_to_copies = {}
 
         for node in objects:
-            # Get the parent of the original object
-            parent_node = node.getParent()
-            copies = []  # List to hold copies of current node
-            original_scale = node.scale.get()
-            scale_steps = [
-                (final_scale - init_scale)
-                for final_scale, init_scale in zip(scale, original_scale)
-            ]
+            copies = []
+            sel_list = om.MSelectionList()
+            sel_list.add(str(node))
+            mobj = sel_list.getDependNode(0)
+            fn_transform = om.MFnTransform(mobj)
+            original_matrix = fn_transform.transformation()
 
             for i in range(num_copies):
                 dup = pm.instance(node)[0]
 
-                # Set the parent of the copy to the same as the original object
-                pm.parent(dup, parent_node)
-
-                x = (i + 1) / num_copies  # Adjusted line
+                x = (i + 1) / num_copies
                 f_x = ptk.lerp(
                     x,
                     x**weight_curve
@@ -52,16 +48,57 @@ class DuplicateLinear:
                     weight_factor,
                 )
 
-                # Now transformations are adjusted directly by f_x
-                dup.translate.set(dup.translate.get() + (pm.dt.Vector(translate) * f_x))
-                dup.rotate.set(dup.rotate.get() + (pm.dt.Vector(rotate) * f_x))
-                dup.scale.set(
-                    [
-                        init_scale + (b * f_x)
-                        for init_scale, b in zip(original_scale, scale_steps)
-                    ]
+                # Create new MTransformationMatrix object
+                new_matrix = om.MTransformationMatrix(original_matrix)
+
+                # Calculate new transformations
+                new_translation = om.MVector(*translate) * f_x
+                new_rotation = om.MEulerRotation(
+                    rotate[0] * f_x, rotate[1] * f_x, rotate[2] * f_x
                 )
 
+                # Handle potential negative scale values
+                new_scale = [(abs(s) ** f_x) * (-1 if s < 0 else 1) for s in scale]
+
+                # Apply transformations
+                new_matrix.setTranslation(new_translation, om.MSpace.kTransform)
+                new_matrix.setRotation(new_rotation)
+                new_matrix.setScale(new_scale, om.MSpace.kTransform)
+
+                # Get existing transformation of duplicate
+                sel_list.add(str(dup))
+                mobj_dup = sel_list.getDependNode(1)
+                fn_transform_dup = om.MFnTransform(mobj_dup)
+                existing_matrix = fn_transform_dup.transformation()
+
+                # Extract existing transformation components
+                existing_translation = existing_matrix.translation(om.MSpace.kTransform)
+                existing_rotation = existing_matrix.rotation()
+                existing_scale = existing_matrix.scale(om.MSpace.kTransform)
+
+                # Combine existing and new transformations
+                combined_translation = existing_translation + new_translation
+                combined_rotation = om.MEulerRotation(
+                    existing_rotation.x + new_rotation.x,
+                    existing_rotation.y + new_rotation.y,
+                    existing_rotation.z + new_rotation.z,
+                )
+                combined_scale = [
+                    existing * new for existing, new in zip(existing_scale, new_scale)
+                ]
+
+                # Create a new MTransformationMatrix for the combined transformation
+                combined_matrix = om.MTransformationMatrix(existing_matrix)
+                combined_matrix.setTranslation(
+                    combined_translation, om.MSpace.kTransform
+                )
+                combined_matrix.setRotation(combined_rotation)
+                combined_matrix.setScale(combined_scale, om.MSpace.kTransform)
+
+                # Apply combined transformation
+                fn_transform_dup.setTransformation(combined_matrix)
+
+                sel_list.remove(1)
                 copies.append(dup)
 
             originals_to_copies[node] = copies
@@ -86,10 +123,32 @@ class DuplicateLinearSlots:
             "valueChanged",
             self.preview.refresh,
         )
+        # Connect valueChanged signals to toggle_weight_ui using connect_multi
+        self.sb.connect_multi(
+            self.ui,
+            "s003-8",
+            "valueChanged",
+            self.toggle_weight_ui,
+        )
+        # Initialize the UI state
+        self.toggle_weight_ui()
+
+    def toggle_weight_ui(self):
+        """Disable weight UI components if rotate values are zero and scale values are one."""
+        is_rotate_zero = all(
+            self.ui.__dict__[f"s00{i}"].value() == 0 for i in range(3, 6)
+        )
+        is_scale_one = all(
+            self.ui.__dict__[f"s00{i}"].value() == 1 for i in range(6, 9)
+        )
+
+        should_disable = is_rotate_zero and is_scale_one
+        self.ui.s010.setDisabled(should_disable)
+        self.ui.s011.setDisabled(should_disable)
 
     def perform_operation(self, objects):
         """Perform the linear duplication operation."""
-        num_copies = self.ui.s009.value()
+        num_copies = self.ui.s009.value() - 1  # Include the orig object in the count
         translate = (
             self.ui.s000.value(),
             self.ui.s001.value(),

--- a/mayatk/edit_utils/duplicate_linear.ui
+++ b/mayatk/edit_utils/duplicate_linear.ui
@@ -215,7 +215,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Duplicate: number of copies</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Duplicate: Total number of duplicated objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="buttonSymbols">
               <enum>QAbstractSpinBox::NoButtons</enum>


### PR DESCRIPTION
- edit_utils.duplicate_linear:  Update to calculate values relative to current,  and to use the Maya api to perform the translations.  Finally,  the weighting spinboxes are disabled in circumstances where they have no effect.