### PR TITLE
0.8.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-0.8.4-blue.svg)](https://pypi.org/project/mayatk/)
+[![Version](https://img.shields.io/badge/Version-0.8.5-blue.svg)](https://pypi.org/project/mayatk/)
 [![CoreUtils Tests](https://img.shields.io/badge/CoreUtils-Passing-brightgreen.svg)](../test/core_utils_test.py#CoreUtilsTest)
 [![ProjUtils Tests](https://img.shields.io/badge/ProjUtils-Passing-brightgreen.svg)](../test/proj_utils_test.py#ProjUtilsTest)
 [![XformUtils Tests](https://img.shields.io/badge/XformUtils-Passing-brightgreen.svg)](../test/xform_utils_test.py#XformUtilsTest)

--- a/mayatk/__init__.py
+++ b/mayatk/__init__.py
@@ -6,7 +6,7 @@ import pkgutil
 
 
 __package__ = "mayatk"
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 """Dynamic Attribute Resolver for Module-based Packages
 

--- a/mayatk/core_utils/preview.py
+++ b/mayatk/core_utils/preview.py
@@ -56,7 +56,7 @@ class Preview:
         create_button,
         finalize_func=None,
         message_func=print,
-        enable_on_show=True,
+        enable_on_show=False,
         disable_on_hide=True,
     ):
         """Initialize the state for preview operations."""
@@ -74,41 +74,24 @@ class Preview:
         self.create_button.clicked.connect(self.finalize_changes)
         self.window = self.create_button.window()
 
-        self._enable_on_show = None
-        self.enable_on_show = enable_on_show
+        self.init_show_hide_behavior(enable_on_show, disable_on_hide)
 
-        self._disable_on_hide = None
+    def init_show_hide_behavior(self, enable_on_show, disable_on_hide):
+        self.enable_on_show = enable_on_show
         self.disable_on_hide = disable_on_hide
 
-    @property
-    def enable_on_show(self):
-        """Boolean property to enable or disable the preview when the window shows."""
-        return self._enable_on_show
+        if hasattr(self.window, "on_show"):
+            self.window.on_show.connect(self.conditionally_enable)
+        if hasattr(self.window, "on_hide"):
+            self.window.on_hide.connect(self.conditionally_disable)
 
-    @enable_on_show.setter
-    def enable_on_show(self, value):
-        if self._enable_on_show is not None and hasattr(self.window, "on_show"):
-            self.window.on_show.disconnect(self.enable)
+    def conditionally_enable(self):
+        if self.enable_on_show:
+            self.enable()
 
-        self._enable_on_show = value
-
-        if self._enable_on_show and hasattr(self.window, "on_show"):
-            self.window.on_show.connect(self.enable)
-
-    @property
-    def disable_on_hide(self):
-        """Boolean property to enable or disable the preview when the window hides."""
-        return self._disable_on_hide
-
-    @disable_on_hide.setter
-    def disable_on_hide(self, value):
-        if self._disable_on_hide is not None and hasattr(self.window, "on_hide"):
-            self.window.on_hide.disconnect(self.disable)
-
-        self._disable_on_hide = value
-
-        if self._disable_on_hide and hasattr(self.window, "on_hide"):
-            self.window.on_hide.connect(self.disable)
+    def conditionally_disable(self):
+        if self.disable_on_hide:
+            self.disable()
 
     def toggle(self, state):
         """Toggles the preview on or off.

--- a/mayatk/core_utils/reference_manager.py
+++ b/mayatk/core_utils/reference_manager.py
@@ -1,0 +1,142 @@
+# !/usr/bin/python
+# coding=utf-8
+import os
+
+try:
+    import pymel.core as pm
+except ImportError as error:
+    print(__file__, error)
+import pythontk as ptk
+
+# from this package:
+from mayatk.core_utils import CoreUtils
+
+
+class ReferenceManager:
+    def __init__(self):
+        self.references = {}
+
+    @property
+    def workspace_root(self):
+        return pm.workspace(q=True, rd=True)
+
+    @workspace_root.setter
+    def workspace_root(self, value):
+        pm.workspace(dir=value)
+
+    def _get_workspace_files(self, search_root, filter_text=""):
+        inc_files = ["*.ma", "*.mb"]
+        workspace_files = ptk.get_dir_contents(
+            search_root,
+            returned_type="filepath",
+            inc_files=inc_files,
+            num_threads=4,
+            recursive=True,
+            group_by_type=True,
+        ).get("filepath", [])
+        if filter_text:
+            workspace_files = ptk.filter_list(workspace_files, inc=[f"*{filter_text}*"])
+        return workspace_files
+
+    def add_reference(self, namespace, file_path):
+        # Validate and create reference
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File {file_path} does not exist.")
+        ref_node = pm.createReference(file_path, namespace=namespace)
+        self.references[
+            namespace
+        ] = ref_node  # Store the reference node, not just the path
+
+    def remove_reference(self, namespace):
+        if namespace in self.references:
+            self.references[namespace].remove()  # Remove the reference in Maya
+            del self.references[namespace]  # Remove from internal dictionary
+
+    def resolve_file_path(self, selected_file, search_root):
+        workspace_files = self._get_workspace_files(search_root)
+        return next((fp for fp in workspace_files if selected_file in fp), None)
+
+
+class ReferenceManagerSlots(ReferenceManager):
+    def __init__(self):
+        super().__init__()
+        self.sb = self.switchboard()
+        self.ui = self.sb.reference_manager
+
+        self.ui.txt000.setText(self.workspace_root)
+        self.ui.txt000.textChanged.connect(self.set_custom_root)
+
+        self.ui.txt001.textChanged.connect(self.update_filtered_list)
+
+        self.ui.list000.doubleClicked.connect(self.add_reference_from_list)
+        self.ui.list000.itemClicked.connect(self.handle_item_click)
+        self.ui.list000.setSelectionMode(
+            self.sb.QtWidgets.QAbstractItemView.MultiSelection
+        )
+
+        self.update_filtered_list()
+
+    def set_custom_root(self):
+        new_dir = self.ui.txt000.text()
+        if os.path.isdir(new_dir):
+            self.custom_root = new_dir
+            self.update_filtered_list()
+
+    def _populate_list(self, file_list):
+        self.ui.list000.clear()
+        self.ui.list000.addItems(file_list)
+
+    def update_filtered_list(self):
+        filter_text = self.ui.txt001.text().strip()
+        search_root = getattr(self, "custom_root", self.workspace_root)
+        file_list = [
+            os.path.basename(fp)
+            for fp in self._get_workspace_files(search_root, filter_text)
+        ]
+        self._populate_list(file_list)
+
+    def handle_item_click(self, item):
+        selected_file = item.text()
+        search_root = getattr(self, "custom_root", self.workspace_root)
+        file_path = self.resolve_file_path(selected_file, search_root)
+        if file_path:
+            namespace = os.path.splitext(selected_file)[0]
+            if item.isSelected():
+                try:
+                    self.add_reference(namespace, file_path)
+                except ValueError:
+                    print(f"Namespace {namespace} already in use.")
+            else:
+                try:
+                    self.remove_reference(
+                        namespace
+                    )  # This now calls the updated remove_reference
+                except KeyError:
+                    print(f"No reference found for namespace {namespace}.")
+
+    def add_reference_from_list(self, index):
+        selected_file = self.ui.list000.itemFromIndex(index).text()
+        search_root = getattr(self, "custom_root", self.workspace_root)
+        file_path = self.resolve_file_path(selected_file, search_root)
+        if file_path:
+            namespace = os.path.splitext(selected_file)[0]
+            self.add_reference(namespace, file_path)
+
+
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from uitk import Switchboard
+
+    parent = CoreUtils.get_main_window()
+    ui_file = os.path.join(os.path.dirname(__file__), "reference_manager.ui")
+    sb = Switchboard(parent, ui_location=ui_file, slot_location=ReferenceManagerSlots)
+
+    sb.current_ui.set_attributes(WA_TranslucentBackground=True)
+    sb.current_ui.set_flags(FramelessWindowHint=True, WindowStaysOnTopHint=True)
+    sb.current_ui.set_style(theme="dark", style_class="translucentBgWithBorder")
+    sb.current_ui.header.configureButtons(minimize_button=True, hide_button=True)
+    sb.current_ui.show(pos="screen", app_exec=True)
+# -----------------------------------------------------------------------------
+# Notes
+# -----------------------------------------------------------------------------

--- a/mayatk/core_utils/reference_manager.ui
+++ b/mayatk/core_utils/reference_manager.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QtUi</class>
+ <widget class="QMainWindow" name="QtUi">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="tabShape">
+   <enum>QTabWidget::Triangular</enum>
+  </property>
+  <property name="dockNestingEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="dockOptions">
+   <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks|QMainWindow::ForceTabbedDocks</set>
+  </property>
+  <widget class="QWidget" name="central_widget">
+   <property name="minimumSize">
+    <size>
+     <width>200</width>
+     <height>130</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_2">
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="Header" name="header">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>REFERENCE MANAGER</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="File">
+        <property name="title">
+         <string>Root</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="txt000"/>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="txt001">
+           <property name="placeholderText">
+            <string>Filter:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="CollapsableGroup" name="scenes_group">
+           <property name="title">
+            <string>• • •</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QListWidget" name="list000"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Header</class>
+   <extends>QLabel</extends>
+   <header>uitk.widgets.header.Header.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CollapsableGroup</class>
+   <extends>QGroupBox</extends>
+   <header>uitk.widgets.collapsableGroup.CollapsableGroup.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+ <designerdata>
+  <property name="gridDeltaX">
+   <number>5</number>
+  </property>
+  <property name="gridDeltaY">
+   <number>5</number>
+  </property>
+  <property name="gridSnapX">
+   <bool>true</bool>
+  </property>
+  <property name="gridSnapY">
+   <bool>true</bool>
+  </property>
+  <property name="gridVisible">
+   <bool>true</bool>
+  </property>
+ </designerdata>
+</ui>

--- a/mayatk/mat_utils/_mat_utils.py
+++ b/mayatk/mat_utils/_mat_utils.py
@@ -217,6 +217,34 @@ class MatUtils(object):
         return objs_with_material
 
     @staticmethod
+    def reload_textures(materials=None, inc=None, exc=None):
+        """Reloads textures connected to specified materials with inclusion/exclusion filters.
+
+        Parameters:
+            materials (str/obj/list): Material or list of materials to process. Defaults to all materials in the scene.
+            inc (str/list): Inclusion patterns for filtering textures.
+            exc (str/list): Exclusion patterns for filtering textures.
+        """
+        materials = pm.ls(materials) if materials else pm.ls(mat=True)
+
+        file_nodes = []
+        for material in materials:
+            # Traverse the connections to find file nodes
+            file_nodes.extend(
+                node_utils.NodeUtils.get_connected_nodes(material, node_type="file")
+            )
+
+        # Remove duplicates
+        file_nodes = set(file_nodes)
+        # Filter file_nodes based on texture names
+        file_nodes = ptk.filter_list(
+            file_nodes, inc=inc, exc=exc, map_func=lambda fn: fn.fileTextureName.get()
+        )
+
+        for fn in file_nodes:
+            pm.evalDeferred(f"pm.runtime.reloadFile('{fn.fileTextureName.get()}')")
+
+    @staticmethod
     def get_mat_swatch_icon(mat, size=[20, 20]):
         """Get an icon with a color fill matching the given materials RBG value.
 

--- a/mayatk/mat_utils/hdr_manager.py
+++ b/mayatk/mat_utils/hdr_manager.py
@@ -1,0 +1,194 @@
+# !/usr/bin/python
+# coding=utf-8
+import os
+
+try:
+    import pymel.core as pm
+except ImportError as error:
+    print(__file__, error)
+import pythontk as ptk
+
+# from this package:
+from mayatk.core_utils import CoreUtils
+from mayatk.node_utils import NodeUtils
+
+
+class HdrManager:
+    hdr_env_name = "aiSkyDomeLight_"
+
+    @property
+    def hdr_env(self) -> object:
+        """ """
+        node = pm.ls(self.hdr_env_name, exactType="aiSkyDomeLight")
+        try:
+            return node[0]
+        except IndexError:
+            return None
+
+    @hdr_env.setter
+    def hdr_env(self, tex) -> None:
+        """ """
+        # NodeUtils.node_exists('aiSkyDomeLight', search='exactType')
+        node = self.hdr_env
+        if not node:
+            node = NodeUtils.create_render_node(
+                "aiSkyDomeLight",
+                "asLight",
+                name=self.hdr_env_name,
+                camera=0,
+                skyRadius=0,
+            )  # turn off skydome and viewport visibility.
+            self.hdr_env_transform.hiddenInOutliner.set(1)
+            pm.outlinerEditor("outlinerPanel1", edit=True, refresh=True)
+
+        file_node = NodeUtils.get_connected_nodes(
+            node, node_type="file", direction="incoming", first_match=True
+        )
+        if not file_node:
+            file_node = NodeUtils.create_render_node(
+                "file", "as2DTexture", texture_node=True
+            )
+            pm.connectAttr(file_node.outColor, node.color, force=True)
+
+        file_node.fileTextureName.set(str(tex))
+
+    @property
+    def hdr_env_transform(self) -> object:
+        """ """
+        node = NodeUtils.get_transform_node(self.hdr_env)
+        if not node:
+            return None
+        return node
+
+    def set_hdr_map_visibility(self, state):
+        """ """
+        node = self.hdr_env
+        if node:
+            node.camera.set(state)
+
+    @CoreUtils.undo
+    def create_network(
+        self,
+        hdrMap="",
+        hdrMapVisibility=False,
+    ):
+        """ """
+        self.hdr_env = hdrMap
+        self.set_hdr_map_visibility(hdrMapVisibility)
+
+
+class HdrManagerSlots(HdrManager):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+        self.sb = self.switchboard()
+        self.ui = self.sb.hdr_manager
+        self.workspace_dir = CoreUtils.get_maya_info("workspace_dir")
+        self.source_images_dir = os.path.join(self.workspace_dir, "sourceimages")
+
+        hdr_info = ptk.get_dir_contents(
+            self.source_images_dir,
+            ["filename", "filepath"],
+            inc_files=["*.exr", "*.hdr"],
+            group_by_type=True,
+        )
+        self.ui.cmb000.add(
+            zip(hdr_info["filename"], hdr_info["filepath"]), ascending=False
+        )
+
+        node = self.hdr_env_transform
+        if node:
+            rotation = node.rotateY.get()
+            self.ui.slider000.setSliderPosition(rotation)
+
+    @property
+    def hdr_map(self) -> str:
+        """Get the hdr map filepath from the comboBoxes current text.
+
+        Returns:
+            (str) data as string.
+        """
+        data = self.ui.cmb000.currentData()
+        return data
+
+    @property
+    def hdr_map_visibility(self) -> bool:
+        """Get the hdr map visibility state from the checkBoxes current state.
+
+        Returns:
+            (bool)
+        """
+        state = self.ui.chk000.isChecked()
+        return state
+
+    def cmb000(self, index, widget):
+        """HDR map selection."""
+        data = widget.currentData()
+
+        self.hdr_env = data  # set the HDR map.
+
+    def chk000(self, state, widget):
+        """ """
+        self.set_hdr_map_visibility(state)  # set the HDR map visibility.
+
+    def slider000(self, value, widget):
+        """Rotate the HDR map."""
+        if self.hdr_env:
+            transform = NodeUtils.get_transform_node(self.hdr_env)
+            pm.rotate(
+                transform,
+                value,
+                rotateY=True,
+                forceOrderXYZ=True,
+                objectSpace=True,
+                absolute=True,
+            )
+
+    def b000(self):
+        """Create network."""
+        self.create_network(
+            hdrMap=self.hdr_map,
+            hdrMapVisibility=self.hdr_map_visibility,
+        )
+
+    # def b001(self):
+    #     """Get texture maps."""
+    #     image_files = self.sb.file_dialog(
+    #         file_types=["*.png", "*.jpg", "*.bmp", "*.tga", "*.tiff", "*.gif"],
+    #         title="Select one or more image files to open.",
+    #         directory=self.source_images_dir,
+    #     )
+
+    #     if image_files:
+    #         self.image_files = image_files
+    #         self.ui.txt001.clear()
+
+    #         msg_mat_selection = self.image_files
+    #         for (
+    #             i
+    #         ) in msg_mat_selection:  # format msg_intro using the map_types in imtools.
+    #             self.callback(ptk.truncate(i, 60))
+
+    #         self.ui.b000.setDisabled(False)
+    #     elif not self.image_files:
+    #         self.ui.b000.setDisabled(True)
+
+
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from uitk import Switchboard
+
+    parent = CoreUtils.get_main_window()
+    ui_file = os.path.join(os.path.dirname(__file__), "hdr_manager.ui")
+    sb = Switchboard(parent, ui_location=ui_file, slot_location=HdrManagerSlots)
+
+    sb.current_ui.set_attributes(WA_TranslucentBackground=True)
+    sb.current_ui.set_flags(FramelessWindowHint=True, WindowStaysOnTopHint=True)
+    sb.current_ui.set_style(theme="dark", style_class="translucentBgWithBorder")
+    sb.current_ui.header.configureButtons(minimize_button=True, hide_button=True)
+    sb.current_ui.show(pos="screen", app_exec=True)
+
+# -----------------------------------------------------------------------------
+# Notes
+# -----------------------------------------------------------------------------

--- a/mayatk/mat_utils/hdr_manager.ui
+++ b/mayatk/mat_utils/hdr_manager.ui
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QtUi</class>
+ <widget class="QMainWindow" name="QtUi">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>173</height>
+   </rect>
+  </property>
+  <property name="tabShape">
+   <enum>QTabWidget::Triangular</enum>
+  </property>
+  <property name="dockNestingEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="dockOptions">
+   <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks|QMainWindow::ForceTabbedDocks</set>
+  </property>
+  <widget class="QWidget" name="central_widget">
+   <property name="minimumSize">
+    <size>
+     <width>200</width>
+     <height>0</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QVBoxLayout" name="main_layout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetFixedSize</enum>
+      </property>
+      <item>
+       <widget class="Header" name="header">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>999</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>HDR MANAGER</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="main_group">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>80</height>
+         </size>
+        </property>
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>1</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>2</number>
+         </property>
+         <item row="2" column="0">
+          <widget class="QGroupBox" name="hdr_rotation_group">
+           <property name="title">
+            <string>HDR Rotation</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>1</number>
+            </property>
+            <property name="topMargin">
+             <number>1</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>1</number>
+            </property>
+            <item>
+             <widget class="QSlider" name="slider000">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>360</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>1</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="chk000">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>60</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Set the HDR map visibility.</string>
+              </property>
+              <property name="text">
+               <string>Visible</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QGroupBox" name="hdr_options_group">
+           <property name="title">
+            <string>HDR Map</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>1</number>
+            </property>
+            <property name="rightMargin">
+             <number>1</number>
+            </property>
+            <property name="bottomMargin">
+             <number>1</number>
+            </property>
+            <item>
+             <widget class="ComboBox" name="cmb000">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>999</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Select an HDR map.</string>
+              </property>
+              <property name="editable">
+               <bool>false</bool>
+              </property>
+              <property name="maxVisibleItems">
+               <number>30</number>
+              </property>
+              <property name="maxCount">
+               <number>20</number>
+              </property>
+              <property name="insertPolicy">
+               <enum>QComboBox::InsertAtTop</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QComboBox::AdjustToContents</enum>
+              </property>
+              <property name="frame">
+               <bool>false</bool>
+              </property>
+              <item>
+               <property name="text">
+                <string>&lt;HDR Map&gt;</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="create_group">
+        <property name="spacing">
+         <number>1</number>
+        </property>
+        <item>
+         <widget class="QProgressBar" name="progressBar">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>4</height>
+           </size>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="textVisible">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="b000">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Set HDR</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Header</class>
+   <extends>QLabel</extends>
+   <header>uitk.widgets.header.Header.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ComboBox</class>
+   <extends>QComboBox</extends>
+   <header>uitk.widgets.comboBox.ComboBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+ <designerdata>
+  <property name="gridDeltaX">
+   <number>5</number>
+  </property>
+  <property name="gridDeltaY">
+   <number>5</number>
+  </property>
+  <property name="gridSnapX">
+   <bool>true</bool>
+  </property>
+  <property name="gridSnapY">
+   <bool>true</bool>
+  </property>
+  <property name="gridVisible">
+   <bool>true</bool>
+  </property>
+ </designerdata>
+</ui>

--- a/mayatk/mat_utils/stingray_arnold_shader.ui
+++ b/mayatk/mat_utils/stingray_arnold_shader.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>463</width>
-    <height>423</height>
+    <height>444</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,7 +71,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>154</height>
+          <height>145</height>
          </size>
         </property>
         <property name="title">
@@ -94,161 +94,60 @@
           <number>1</number>
          </property>
          <property name="verticalSpacing">
-          <number>2</number>
+          <number>0</number>
          </property>
-         <item row="1" column="2">
-          <widget class="QGroupBox" name="hdr_rotation_group">
+         <item row="0" column="0" colspan="2">
+          <widget class="QGroupBox" name="material_name_group">
            <property name="minimumSize">
             <size>
-             <width>0</width>
+             <width>300</width>
              <height>40</height>
             </size>
            </property>
-           <property name="title">
-            <string>HDR Rotation</string>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>50</height>
+            </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <property name="title">
+            <string>Material Name</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
             <property name="spacing">
-             <number>0</number>
+             <number>1</number>
             </property>
             <property name="leftMargin">
-             <number>1</number>
+             <number>0</number>
             </property>
             <property name="topMargin">
              <number>1</number>
             </property>
             <property name="rightMargin">
-             <number>0</number>
+             <number>1</number>
             </property>
             <property name="bottomMargin">
              <number>1</number>
             </property>
             <item>
-             <widget class="QSlider" name="slider000">
+             <widget class="QLineEdit" name="txt000">
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>360</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>1</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QGroupBox" name="hdr_map_group">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>40</height>
-            </size>
-           </property>
-           <property name="title">
-            <string>HDR Map</string>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>1</number>
-            </property>
-            <property name="rightMargin">
-             <number>1</number>
-            </property>
-            <property name="bottomMargin">
-             <number>1</number>
-            </property>
-            <item>
-             <widget class="ComboBox" name="cmb000">
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
                 <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
                 <width>999</width>
-                <height>20</height>
+                <height>16777215</height>
                </size>
               </property>
               <property name="toolTip">
-               <string>Select the HDR map.</string>
+               <string>Name the material.</string>
               </property>
-              <property name="editable">
-               <bool>false</bool>
-              </property>
-              <property name="maxVisibleItems">
-               <number>30</number>
-              </property>
-              <property name="maxCount">
-               <number>20</number>
-              </property>
-              <property name="insertPolicy">
-               <enum>QComboBox::InsertAtTop</enum>
-              </property>
-              <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToContents</enum>
-              </property>
-              <property name="frame">
-               <bool>false</bool>
-              </property>
-              <item>
-               <property name="text">
-                <string>&lt;HDR Map&gt;</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="chk000">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Set the HDR map visibility.</string>
-              </property>
-              <property name="text">
-               <string>Visible</string>
+              <property name="placeholderText">
+               <string>&lt;Material Name&gt;</string>
               </property>
              </widget>
             </item>
@@ -260,6 +159,12 @@
            <property name="minimumSize">
             <size>
              <width>0</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
              <height>40</height>
             </size>
            </property>
@@ -332,18 +237,12 @@
            </layout>
           </widget>
          </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QGroupBox" name="material_name_group">
-           <property name="minimumSize">
-            <size>
-             <width>300</width>
-             <height>40</height>
-            </size>
-           </property>
+         <item row="1" column="0" colspan="3">
+          <widget class="QGroupBox" name="create_network_group">
            <property name="title">
-            <string>Material Name</string>
+            <string/>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <layout class="QVBoxLayout" name="verticalLayout_2">
             <property name="spacing">
              <number>1</number>
             </property>
@@ -351,139 +250,107 @@
              <number>0</number>
             </property>
             <property name="topMargin">
-             <number>1</number>
+             <number>0</number>
             </property>
             <property name="rightMargin">
-             <number>1</number>
+             <number>0</number>
             </property>
             <property name="bottomMargin">
-             <number>1</number>
+             <number>0</number>
             </property>
             <item>
-             <widget class="QLineEdit" name="txt000">
+             <widget class="QPushButton" name="b001">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
-                <width>0</width>
-                <height>20</height>
+                <width>200</width>
+                <height>30</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
-                <width>999</width>
-                <height>16777215</height>
+                <width>16777215</width>
+                <height>30</height>
                </size>
               </property>
-              <property name="toolTip">
-               <string>Name the material.</string>
+              <property name="text">
+               <string>Get Texture Maps</string>
               </property>
-              <property name="placeholderText">
-               <string>&lt;Material Name&gt;</string>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="b000">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Create Network</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QProgressBar" name="progressBar">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>4</height>
+               </size>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+              <property name="textVisible">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
            </layout>
           </widget>
          </item>
-         <item row="6" column="0" colspan="3">
-          <layout class="QVBoxLayout" name="network_group">
-           <property name="spacing">
-            <number>1</number>
-           </property>
-           <item>
-            <widget class="QPushButton" name="b001">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>200</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Get Texture Maps</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="b000">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>200</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Create Network</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QProgressBar" name="progressBar">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>4</height>
-              </size>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-             <property name="textVisible">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
        </widget>
       </item>
       <item>
-       <widget class="CollapsableGroup" name="text_group">
+       <widget class="CollapsableGroup" name="groupBox_2">
         <property name="title">
          <string>• • •</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
         </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -502,7 +369,7 @@
             <enum>Qt::ScrollBarAlwaysOff</enum>
            </property>
            <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContents</enum>
+            <enum>QAbstractScrollArea::AdjustIgnored</enum>
            </property>
           </widget>
          </item>
@@ -518,7 +385,7 @@
   <customwidget>
    <class>Header</class>
    <extends>QLabel</extends>
-   <header>header.h</header>
+   <header>uitk.widgets.header.Header.h</header>
   </customwidget>
   <customwidget>
    <class>ComboBox</class>

--- a/test/node_utils_test.py
+++ b/test/node_utils_test.py
@@ -176,13 +176,9 @@ class NodeUtils_test(Main, NodeUtils):
         """ """
         # self.assertEqual(self.create_render_node(), None)
 
-    def test_getIncomingNodeByType(self):
+    def test_get_connected_nodes(self):
         """ """
         # self.get_incoming_node_by_type(), None)
-
-    def test_getOutgoingNodeByType(self):
-        """ """
-        # self.assertEqual(self.get_outgoing_node_by_type(), None)
 
     def test_connectMultiAttr(self):
         """ """


### PR DESCRIPTION
- cam_utils.adjust_camera_clipping:  Refactored to allow for resetting the clipping back to defaults.
- core_utils.preview: Refactored the enable/disable on visibility change properties to be simpler and more robust,  while fixing a potential RuntimeError on disconnect.
- core_utils.reference_manager: Added the reference manager module and UI.
- mat_utils.reload_textures:  Added the reload textures method.
- mat_utils.hdr_manager:  Split the existing HDR logic from stingray arnold shader to it's own module and UI.
- mat_utils.stingray_arnold_shader: Fixed a layout issue in the UI that prevented the text group box from collapsing.  Some minor refactoring.
- node_utils.get_connected_nodes: Consolidated existing node connection methods into a single more powerful function.