### PR TITLE
0.9.28

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-0.9.27-blue.svg)](https://pypi.org/project/mayatk/)
+[![Version](https://img.shields.io/badge/Version-0.9.28-blue.svg)](https://pypi.org/project/mayatk/)
 [![CoreUtils Tests](https://img.shields.io/badge/CoreUtils-Passing-brightgreen.svg)](../test/core_utils_test.py#CoreUtilsTest)
 [![XformUtils Tests](https://img.shields.io/badge/XformUtils-Passing-brightgreen.svg)](../test/xform_utils_test.py#XformUtilsTest)
 [![EditUtils Tests](https://img.shields.io/badge/EditUtils-Passing-brightgreen.svg)](../test/edit_utils_test.py#EditUtilsTest)

--- a/mayatk/__init__.py
+++ b/mayatk/__init__.py
@@ -7,7 +7,7 @@ import pkgutil
 
 
 __package__ = "mayatk"
-__version__ = "0.9.27"
+__version__ = "0.9.28"
 
 """Dynamic Attribute Resolver for Module-based Packages
 

--- a/mayatk/ui_utils/maya_menu_handler.py
+++ b/mayatk/ui_utils/maya_menu_handler.py
@@ -40,14 +40,9 @@ class MayaMenuHandler(ptk.LoggingMixin):
     """Handles Maya's menu retrieval and embedding into UI components."""
 
     MENU_MAPPING = {
-        "animation": {
-            "maya_name": "Animation",
-            "command": "buildAnimationMenu MayaWindow|mainAnimationMenu",
-            "menu_set": "animationMenuSet",
-        },
         "arnold": {
             "maya_name": "Arnold",
-            "command": "",  # Specific Arnold initialization if needed
+            "command": 'if (!`pluginInfo -q -l "mtoa"`) loadPlugin "mtoa";',
             "menu_set": "renderingMenuSet",
         },
         "cache": {
@@ -137,7 +132,7 @@ class MayaMenuHandler(ptk.LoggingMixin):
         },
         "mash": {
             "maya_name": "MASH",
-            "command": "",  # Specific initialization might be needed
+            "command": 'if (!`pluginInfo -q -l "MASH"`) loadPlugin "MASH";',
             "menu_set": "animationMenuSet",
         },
         "mesh": {
@@ -185,15 +180,10 @@ class MayaMenuHandler(ptk.LoggingMixin):
             "command": "AniPlaybackMenu MayaWindow|mainPlaybackMenu",
             "menu_set": "animationMenuSet",
         },
-        "rendering": {
-            "maya_name": "Rendering",
+        "render": {
+            "maya_name": "Render",
             "command": "RenRenderMenu MayaWindow|mainRenderMenu",
             "menu_set": "renderingMenuSet",
-        },
-        "rigging": {
-            "maya_name": "Rigging",
-            "command": "buildRiggingMenu MayaWindow|mainRiggingMenu",
-            "menu_set": "riggingMenuSet",
         },
         "select": {
             "maya_name": "Select",


### PR DESCRIPTION
Update: ui_utils.maya_menu_handler:  fixed arnold and mash initializatiion.  Removed non menu items from the menu_mapping.  Added render menu.